### PR TITLE
SmartHQ library initial testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [?.?.?](https://github.com/homebridge-plugins/ge-smarthq/releases/tag/v1.0.1) (2026-03-15)
+
+## What's Changed
+- OAuth2 initial authentication process for Digital Twin API
+- Client Id and Client secret passed via config.schema.json
+- Access, refresh tokens and expire changed to static vars
+- Additional error handling for 401 (invalid credentials) errors
+- Add new function 'sendCommand' for command to single device
+- Handling of the http headers (authorization)
+- Add requirement for initial setup of SmartHQ account in order to use Digital Twin API
+
 ## [1.0.1](https://github.com/homebridge-plugins/ge-smarthq/releases/tag/v1.0.1) (2026-02-12)
 
 ## What's Changed
 * No notable changes
+
 
 **Full Changelog**: https://github.com/homebridge-plugins/ge-smarthq/compare/...v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add ge-smarthq
 - Node.js 20.x, 22.x, or 24.x
 - npm or yarn package manager
 - GE SmartHQ account with OAuth2 credentials (optional - defaults are provided)
-
+<!--
 ## Environment Variables
 
 By default, this library uses public OAuth2 credentials for the GE SmartHQ API. You can override these by setting environment variables (useful for custom or restricted API access):
@@ -41,7 +41,7 @@ SMARTHQ_OAUTH2_CLIENT_SECRET=your_client_secret_here
 ```
 
 **Important**: Never commit `.env` files to version control. Use `.env.local` or similar for local development. See [.env.example](.env.example) for the template.
-
+-->
 ## Quick Start
 
 ### Basic Usage
@@ -50,13 +50,13 @@ SMARTHQ_OAUTH2_CLIENT_SECRET=your_client_secret_here
 import { SmartHQClient } from 'ge-smarthq';
 
 // Create client instance
-const client = new SmartHQClient({
-  username: 'your-email@example.com',
-  password: 'your-password',
-  region: 'US', // or 'EU'
-  debug: false,
-});
-
+this.client = new SmartHQClient(
+      {
+      clientId:     'your-client-id',
+      clientSecret: 'your-client-secret',
+      redirectUri:  'your-redirect-uri',
+      debug:        false,
+    });
 // Authenticate
 await client.authenticate();
 
@@ -76,18 +76,19 @@ client.on('service_update', (message) => {
 await client.disconnect();
 ```
 
-### Sending Commands
+### Sending Command
 
 ```typescript
-await client.sendCommands({
-  kind: 'appliance#command-request',
-  commands: [
-    {
-      kind: 'appliance#command',
-      deviceId: 'your-device-id',
-      action: 'start',
-    },
-  ],
+await client.sendCommand({
+  kind: 'service#command',
+  deviceId:           'your-deviceId',
+  serviceDeviceType:  'your-service-device-type',
+  serviceType:        'your-service-type',
+  domainType:         'your-domain-type'
+  command: {
+    commandType: 'your-command-type',
+    value:        value 
+  },
 });
 ```
 
@@ -119,18 +120,22 @@ console.log('Online:', presence.presence?.online);
 
 ```typescript
 interface SmartHQConfig {
-  username: string;        // GE account email
-  password: string;        // GE account password
-  region?: 'US' | 'EU';    // Region (default: 'US')
+  clientId: string;        // SmartHQ account client Id
+  clientSecret: string;    // SmartHQ account client Secret
+  redirectUri:  string;    // redirectURI for SmartHQ API
   debug?: boolean;         // Enable debug logging (default: false)
 }
 ```
+- To obtain a client Id and clientSecret follow the steps at [Get Started - SmartHQ Docs](https://docs.smarthq.com/get-started/)  
+- The authenticate() function will start a localhost server which is used for the redirectUri.  Example: http://localhost:8888/callback
 
 ### Client Methods
 
 #### Authentication
 
 - **`authenticate(): Promise<void>`** - Log in and obtain OAuth2 credentials
+
+
 
 #### Device Management
 
@@ -146,6 +151,7 @@ interface SmartHQConfig {
 
 #### Commands
 
+- **`sendCommand(request: SendCommandRequest): Promise<SendCommandSuccessResponse>`** - Execute command for single device
 - **`sendCommands(request: SendCommandsRequest): Promise<SendCommandsSuccessResponse>`** - Execute commands
 
 #### Alerts & Presence
@@ -224,15 +230,16 @@ client.on('error', (error: Error) => {
 
 ## Advanced Usage
 
-### Custom Region and Debug Logging
+### Debug Logging
 
 ```typescript
-const client = new SmartHQClient({
-  username: 'user@example.com',
-  password: 'password',
-  region: 'EU',
-  debug: true, // Enable debug output
-});
+const client = new SmartHQClient(
+      {
+      clientId:     '1234567898765432',
+      clientSecret: '1ju739ff93l0c873kaj92',
+      redirectUri:  'http://localhost:8888/callback',
+      debug:        true, // Enable debug output
+    });
 ```
 
 ### Error Handling
@@ -276,6 +283,54 @@ The API supports all GE SmartHQ-enabled appliances, including:
 
 To use this library in a Homebridge plugin:
 
+- Requires an account and setup documented in the steps at [Get Started - SmartHQ Docs](https://docs.smarthq.com/get-started/)  
+- A config.schema.json file that includes  clientId, clientSecret, redirectUri
+
+example config.schema.json ----
+```typescript
+{
+  "pluginAlias": "SmartHqPlatform",
+  "pluginType": "platform",
+  "singular": true,
+  "schema": {
+    "type": "object",
+    "required": ["clientId", "clientSecret", "redirectUri"],
+    "properties": {
+      "clientId": {
+        "type": "string",
+        "title": "SmartHQ Client ID",
+        "x-schema-form": {
+          "type": "password"
+        }
+      },
+      "clientSecret": {
+        "type": "string",
+        "title": "SmartHQ Client Secret",
+        "x-schema-form": {
+          "type": "password"
+        }
+      },
+      "redirectUri": {
+        "type": "string",
+        "format": "uri",
+        "title": "OAuth Redirect URI (must match the one defined  for SmartHQ app @ https://developer.smarthq.com/user/???/apps",
+        "default": "http://localhost:8888/callback"
+      },
+      "debugLogging": {
+        "type": "boolean",
+        "title": "Plugin Debug Logging",
+        "default": false
+      },
+    }
+```
+
+- To obtain the initial access token and refresh token requires additional steps. Once the tokens are saved these steps will only be required if the token store file is deleted or missing. 
+  - Monitor the Homebridge log for '[SmarthqClient] Click to login for SmartHQ Auth setup ===>: http://localhost:8888/login
+  - Click the url to redirect to SmartHQ authorization website.
+  - Login with your account username and password.
+  - An auth code is returned to the redirectUri which is used to acquire the access and refresh tokens.
+  - The localhost server to handle the redirect is started internally so no extra action is required
+
 ```typescript
 import { SmartHQClient } from 'ge-smarthq';
 
@@ -283,20 +338,31 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
   private client: SmartHQClient;
 
   constructor(log: Logger, config: PlatformConfig, api: API) {
-    this.client = new SmartHQClient({
-      username: config.username,
-      password: config.password,
-      region: config.region || 'US',
-      debug: config.debug || false,
+    this.client = new SmartHQClient(
+      {
+      clientId:     this.config.clientId,
+      clientSecret: this.config.clientSecret,
+      redirectUri:  this.config.redirectUri,
+      debug:        this.config.debugLogging || false,
     });
 
     this.api.on('didFinishLaunching', () => {
-      this.discoverDevices();
-    });
+      try {
+        await this.client.authenticate();
+      } catch (error) {
+          console.error('SmartHQ OAuth2 authentication failed:'), error);
+      }
+      // Listen for authComplete event to start device discovery
+      this.client.on('authenticated', async () => {
+        try {
+        await this.discoverDevices();
+        } catch (error) {
+          console.error('Error during device discovery:'), error);
+        }
+    };
   }
 
   async discoverDevices() {
-    await this.client.authenticate();
     const devices = await this.client.getDevices();
     // Create HomeKit accessories for each device
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,15 +6,16 @@
   "packages": {
     "": {
       "name": "ge-smarthq",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.11.0",
+        "express": "^5.2.1",
         "ws": "^8.19.0"
       },
       "devDependencies": {
         "@antfu/eslint-config": "^7.0.1",
-        "@types/node": "^25.0.9",
+        "@types/node": "^25.2.3",
         "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
@@ -163,36 +164,6 @@
         }
       }
     },
-    "node_modules/@antfu/eslint-config/node_modules/eslint-plugin-vue": {
-      "version": "10.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "natural-compare": "^1.4.0",
-        "nth-check": "^2.1.1",
-        "postcss-selector-parser": "^7.1.0",
-        "semver": "^7.6.3",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
-        "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "vue-eslint-parser": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@stylistic/eslint-plugin": {
-          "optional": true
-        },
-        "@typescript-eslint/parser": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
       "dev": true,
@@ -306,6 +277,74 @@
         "node": ">=10"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.3",
       "cpu": [
@@ -316,6 +355,363 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -373,22 +769,37 @@
       }
     },
     "node_modules/@eslint/compat": {
-      "version": "1.4.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.2.tgz",
+      "integrity": "sha512-pR1DoD0h3HfF675QZx0xsyrsU8q70Z/plx7880NOhS02NuWLgBCOMDL787nUeQ7EWLkxv3bPQJaarjcPQb2Dwg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.1.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "peerDependencies": {
-        "eslint": "^8.40 || 9"
+        "eslint": "^8.40 || 9 || 10"
       },
       "peerDependenciesMeta": {
         "eslint": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@eslint/compat/node_modules/@eslint/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-array": {
@@ -460,7 +871,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -673,6 +1086,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@ota-meshi/ast-token-store": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@ota-meshi/ast-token-store/-/ast-token-store-0.2.1.tgz",
+      "integrity": "sha512-+8oB1wcOSWJCR6vAm2ioSLas7SoPwp+8tZ1Tcy8DSVEHMip6jxxlGu6EsRzJLAYVCyzKQ38B5pAqSbon1l1rmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "@eslint/markdown": "^7.4.0",
+        "eslint": ">=9.0.0"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "dev": true,
@@ -684,6 +1114,34 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.57.1",
       "cpu": [
@@ -694,6 +1152,314 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -859,6 +1625,8 @@
     },
     "node_modules/@types/node": {
       "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -881,17 +1649,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.55.0.tgz",
-      "integrity": "sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.55.0",
-        "@typescript-eslint/type-utils": "8.55.0",
-        "@typescript-eslint/utils": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/type-utils": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -904,8 +1672,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.55.0",
-        "eslint": "^8.57.0 || ^9.0.0",
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -920,16 +1688,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.55.0.tgz",
-      "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.55.0",
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/typescript-estree": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -940,17 +1708,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.55.0",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
+        "@typescript-eslint/tsconfig-utils": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -965,14 +1735,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.55.0.tgz",
-      "integrity": "sha512-fVu5Omrd3jeqeQLiB9f1YsuK/iHFOwb04bCtY4BSCLgjNbOD33ZdV6KyEqplHr+IlpgT0QTZ/iJ+wT7hvTx49Q==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0"
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -983,7 +1753,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.55.0",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -998,15 +1770,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.55.0.tgz",
-      "integrity": "sha512-x1iH2unH4qAt6I37I2CGlsNs+B9WGxurP2uyZLRz6UJoZWDBx9cJL1xVN/FiOmHEONEg6RIufdvyT0TEYIgC5g==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/typescript-estree": "8.55.0",
-        "@typescript-eslint/utils": "8.55.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -1018,14 +1790,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.55.0.tgz",
-      "integrity": "sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1037,16 +1809,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.55.0.tgz",
-      "integrity": "sha512-EwrH67bSWdx/3aRQhCoxDaHM+CrZjotc2UCCpEDVqfCE+7OjKAGWNY2HsCSTEVvWH2clYQK8pdeLp42EVs+xQw==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.55.0",
-        "@typescript-eslint/tsconfig-utils": "8.55.0",
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0",
+        "@typescript-eslint/project-service": "8.56.0",
+        "@typescript-eslint/tsconfig-utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
         "debug": "^4.4.3",
         "minimatch": "^9.0.5",
         "semver": "^7.7.3",
@@ -1064,24 +1836,37 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1091,14 +1876,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.55.0",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.55.0",
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/typescript-estree": "8.55.0"
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1108,19 +1895,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.55.0.tgz",
-      "integrity": "sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.55.0",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.56.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1131,13 +1918,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1181,7 +1968,9 @@
       }
     },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.6.7",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.9.tgz",
+      "integrity": "sha512-9WfPx1OwJ19QLCSRLkqVO7//1WcWnK3fE/3fJhKMAmDe8+9G4rB47xCNIIeCq3FdEzkIoLTfDlwDlPBaUTMhow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1366,6 +2155,44 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1390,9 +2217,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1679,6 +2506,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bonjour-hap": {
       "version": "3.10.0",
       "dev": true,
@@ -1768,6 +2619,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "dev": true,
@@ -1812,7 +2672,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2017,6 +2876,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.48.0",
       "dev": true,
@@ -2107,7 +3006,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2183,6 +3081,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -2273,6 +3180,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "dev": true,
@@ -2284,6 +3197,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -2504,6 +3426,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2518,7 +3446,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2528,7 +3458,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/js": "9.39.3",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -2590,17 +3520,19 @@
       }
     },
     "node_modules/eslint-config-flat-gitignore": {
-      "version": "2.1.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-flat-gitignore/-/eslint-config-flat-gitignore-2.2.1.tgz",
+      "integrity": "sha512-wA5EqN0era7/7Gt5Botlsfin/UNY0etJSEeBgbUlFLFrBi47rAN//+39fI7fpYcl8RENutlFtvp/zRa/M/pZNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/compat": "^1.2.5"
+        "@eslint/compat": "^2.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
-        "eslint": "^9.5.0"
+        "eslint": "^9.5.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-flat-config-utils": {
@@ -2842,7 +3774,9 @@
       }
     },
     "node_modules/eslint-plugin-import-lite": {
-      "version": "0.5.0",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-lite/-/eslint-plugin-import-lite-0.5.1.tgz",
+      "integrity": "sha512-J+EqremfzXlB1WA/SKQxdZ2yeXgtpCorbcN0wS1KOTLnlSYiGR62MvAtM0zNWy1oDMjL/Lqkqf92Ahs1V5lyUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2869,7 +3803,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.5.4",
+      "version": "62.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.7.0.tgz",
+      "integrity": "sha512-jootujJOIGMkCLN+/WgDFKtaclCt2MEEy9cZ1RyK19Az1JvVI3awbeMXNlJ6y4h8RWIJpcXqmxsu4t9NThYbNw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2884,7 +3820,7 @@
         "html-entities": "^2.6.0",
         "object-deep-merge": "^2.0.0",
         "parse-imports-exports": "^0.2.4",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "spdx-expression-parse": "^4.0.0",
         "to-valid-identifier": "^1.0.0"
       },
@@ -2892,7 +3828,7 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/@es-joy/jsdoccomment": {
@@ -2987,7 +3923,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "17.23.2",
+      "version": "17.24.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
+      "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3031,18 +3969,20 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
-      "version": "5.5.0",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.6.0.tgz",
+      "integrity": "sha512-pxrLrfRp5wl1Vol1fAEa/G5yTXxefTPJjz07qC7a8iWFXcOZNuWBItMQ2OtTzfQIvMq6bMyYcrzc3Wz++na55Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.54.0",
+        "@typescript-eslint/utils": "^8.56.0",
         "natural-orderby": "^5.0.0"
       },
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.45.0"
+        "eslint": "^8.45.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-pnpm": {
@@ -3093,12 +4033,15 @@
       }
     },
     "node_modules/eslint-plugin-toml": {
-      "version": "1.0.4",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-toml/-/eslint-plugin-toml-1.1.1.tgz",
+      "integrity": "sha512-Gg7wxVIYe2bJ1GqcOxmkVqdd1ScE2U3Ia3Q7RLgBhV9NVhAfkFaAOCRwRAAJ2TkbM/dQmXvNuFmAPx4y5XqIHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/core": "^1.0.1",
         "@eslint/plugin-kit": "^0.6.0",
+        "@ota-meshi/ast-token-store": "^0.2.1",
         "debug": "^4.1.1",
         "toml-eslint-parser": "^1.0.1"
       },
@@ -3206,13 +4149,48 @@
         }
       }
     },
+    "node_modules/eslint-plugin-vue": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.8.0.tgz",
+      "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "natural-compare": "^1.4.0",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^7.1.0",
+        "semver": "^7.6.3",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+        "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "vue-eslint-parser": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@stylistic/eslint-plugin": {
+          "optional": true
+        },
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-yml": {
-      "version": "3.1.2",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-3.2.1.tgz",
+      "integrity": "sha512-/oFj7MWk56AKLelLSUb7zN1OKDI9kR+uKEzbf/sGu7Bov0tJs3qwtMcu+VCcEtFAFD7KZe0LSYhyy0Uq8hKF9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/core": "^1.0.1",
         "@eslint/plugin-kit": "^0.6.0",
+        "@ota-meshi/ast-token-store": "^0.2.1",
         "debug": "^4.3.2",
         "diff-sequences": "^29.0.0",
         "escape-string-regexp": "5.0.0",
@@ -3389,6 +4367,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
@@ -3411,6 +4398,74 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/exsolve": {
@@ -3530,6 +4585,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3634,6 +4710,24 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/from": {
@@ -4051,6 +5145,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4104,6 +5234,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4117,6 +5253,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4380,6 +5525,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -5072,6 +6223,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5733,7 +6905,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -5801,6 +6972,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-persist": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
@@ -5818,14 +6998,16 @@
       "license": "MIT"
     },
     "node_modules/nodemon": {
-      "version": "3.1.11",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^4",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.1",
         "pstree.remy": "^1.1.8",
         "semver": "^7.5.3",
         "simple-update-notifier": "^2.0.0",
@@ -5844,12 +7026,51 @@
         "url": "https://opencollective.com/nodemon"
       }
     },
+    "node_modules/nodemon/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/nodemon/node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/nodemon/node_modules/has-flag": {
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/minimatch": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nodemon/node_modules/supports-color": {
@@ -5893,7 +7114,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5993,6 +7213,27 @@
       "version": "2.0.11",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -6099,6 +7340,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6125,6 +7375,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -6305,6 +7565,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -6355,6 +7628,21 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "dev": true,
@@ -6398,6 +7686,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -6598,6 +7910,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6694,6 +8022,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.4.4",
       "dev": true,
@@ -6724,6 +8058,76 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -6773,6 +8177,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6800,7 +8210,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6820,7 +8229,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6837,7 +8245,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6856,7 +8263,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6970,6 +8376,15 @@
       "version": "0.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -7235,6 +8650,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/toml-eslint-parser": {
       "version": "1.0.3",
       "dev": true,
@@ -7396,6 +8820,45 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "dev": true,
@@ -7467,7 +8930,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.16",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.17.tgz",
+      "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7488,20 +8953,37 @@
         "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
       }
     },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7620,6 +9102,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "dev": true,
@@ -7663,6 +9154,15 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -7852,14 +9352,16 @@
       }
     },
     "node_modules/vue-eslint-parser": {
-      "version": "10.2.0",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.0.tgz",
+      "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
-        "eslint-scope": "^8.2.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.2.0 || ^9.0.0",
+        "eslint-visitor-keys": "^4.2.0 || ^5.0.0",
+        "espree": "^10.3.0 || ^11.0.0",
         "esquery": "^1.6.0",
         "semver": "^7.6.3"
       },
@@ -7870,7 +9372,7 @@
         "url": "https://github.com/sponsors/mysticatea"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
@@ -8009,6 +9511,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,12 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
+    "express": "^5.2.1",
     "ws": "^8.19.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^7.0.1",
-    "@types/node": "^25.0.9",
+    "@types/node": "^25.2.3",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -6,9 +6,9 @@ describe('smartHQClient', () => {
 
   beforeEach(() => {
     client = new SmartHQClient({
-      username: 'test@example.com',
-      password: 'test-password',
-      region: 'US',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      redirectUri: 'http://localhost:8888/callback',
       debug: false,
     })
   })
@@ -214,9 +214,9 @@ describe('smartHQClient', () => {
       }
 
       const integrationClient = new SmartHQClient({
-        username,
-        password,
-        region: 'US',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        redirectUri: 'http://localhost:8888/callback',
         debug: false,
       })
 
@@ -234,17 +234,17 @@ describe('smartHQClient', () => {
       }
 
       const integrationClient = new SmartHQClient({
-        username,
-        password,
-        region: 'US',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        redirectUri: 'http://localhost:8888/callback',
         debug: false,
       })
 
       await integrationClient.authenticate()
       const response = await integrationClient.getDevices()
 
-      expect(response).toHaveProperty('items')
-      expect(Array.isArray(response.items)).toBe(true)
+      expect(response).toHaveProperty('devices')
+      expect(Array.isArray(response.devices)).toBe(true)
     })
   })
 })

--- a/src/api/ge-client.ts
+++ b/src/api/ge-client.ts
@@ -1,7 +1,15 @@
-import { EventEmitter } from 'node:events'
-import WebSocket from 'ws'
-import type { AxiosInstance } from 'axios'
-import axios from 'axios'
+import { EventEmitter }       from 'node:events'
+import WebSocket              from 'ws'
+import type { AxiosError, AxiosInstance, AxiosResponse } from 'axios'
+import axios                  from 'axios'
+import chalk                  from 'chalk'
+import fs                     from 'fs'
+import { writeFileSync, existsSync, readFileSync } from 'fs';
+import express                from 'express'
+import path                   from 'node:path'
+import { Server }             from 'http'
+import { stringify, parse }   from 'querystring';
+
 import type {
   AlertCountResponse,
   AlertMessage,
@@ -40,6 +48,8 @@ import type {
   SchemaListResponse,
   SchemaPolicyValidationResponse,
   SchemaResponse,
+  SendCommandRequest,
+  SendCommandSuccessResponse,
   SendCommandsRequest,
   SendCommandsSuccessResponse,
   ServiceDetailsResponse,
@@ -47,27 +57,19 @@ import type {
   ServiceMessage,
   SmartHQClientEventType,
   SmartHQConfig,
-  SmartHQCredentials,
   UpdateFavoriteOrderRequest,
   UpdateFavoriteOrderResponse,
   UpdateFavoriteRequest,
   UpdateFavoriteResponse,
   WebsocketEndpoint,
-} from '../types/index'
+} from '../types/index.js'
 
 // SmartHQ API v2 Constants
-const API_BASE_URL = 'https://client.mysmarthq.com'
-// eslint-disable-next-line node/prefer-global/process
-const OAUTH2_CLIENT_ID = process.env.SMARTHQ_OAUTH2_CLIENT_ID || '564c31616c4f7474434b307435412b4d2f6e7672'
-// eslint-disable-next-line node/prefer-global/process
-const OAUTH2_CLIENT_SECRET = process.env.SMARTHQ_OAUTH2_CLIENT_SECRET || '6476512b5246446d452f697154444941387052645938466e5671746e5847593d'
-const OAUTH2_REDIRECT_URI = 'brillion://oauth/redirect'
-const LOGIN_URL = 'https://accounts.brillion.geappliances.com'
+const API_BASE_URL =          'https://client.mysmarthq.com'
+const LOGIN_URL =             'https://accounts.brillion.geappliances.com'
+const TOKEN_STORE =           "smarthq.tokens.json"
+const PING_INTERVAL =         60000; // 60 seconds
 
-const LOGIN_REGIONS = {
-  US: 'us-east-1',
-  EU: 'eu-west-1',
-}
 
 /**
  * GE SmartHQ API Client
@@ -79,20 +81,26 @@ const LOGIN_REGIONS = {
  * - Alert and presence tracking
  */
 export class SmartHQClient extends EventEmitter {
-  private config: SmartHQConfig
-  private httpClient: AxiosInstance
-  private credentials: SmartHQCredentials | null = null
-  private websocket: WebSocket | null = null
-  private devices: Map<string, Device> = new Map()
+  private config:         SmartHQConfig
+  public httpClient:      AxiosInstance
+  public websocket:       WebSocket | null = null
+  private devices:        Map<string, Device> = new Map()
   private reconnectAttempts = 0
   private maxReconnectAttempts = 5
-  private pingInterval: ReturnType<typeof setInterval> | null = null
-  private pongTimeout: ReturnType<typeof setTimeout> | null = null
+  private pingInterval:   ReturnType<typeof setInterval> | null = null
+  private pongTimeout:    ReturnType<typeof setTimeout> | null = null
+  private tokenPath:      string = '';
+  private oauthServer?:   Server;
+  // Static properties to hold tokens and expiration time
+  static refresh_token:   string = '';
+  static access_token:    string = '';
+  static expires:         number = 0
 
-  constructor(config: SmartHQConfig) {
+  constructor(
+    config: SmartHQConfig,
+  ) {
     super()
     this.config = {
-      region: 'US',
       debug: false,
       ...config,
     }
@@ -101,89 +109,184 @@ export class SmartHQClient extends EventEmitter {
       baseURL: API_BASE_URL,
       timeout: 30000,
     })
+    
+    this.tokenPath = path.join(process.cwd(), TOKEN_STORE)
+
+    this.loadAccessToken();
+
+    chalk.level = 1; // Enable chalk colors 
   }
 
   /**
    * Authenticate with the SmartHQ API using OAuth2
    */
-  async authenticate(): Promise<void> {
-    try {
-      const tokenData = await this.getOAuth2Token()
-      this.credentials = {
-        access_token: tokenData.access_token,
-        token_type: tokenData.token_type || 'Bearer',
-        expires_in: tokenData.expires_in,
-        refresh_token: tokenData.refresh_token,
-        expires: Date.now() + ((tokenData.expires_in || 3600) * 1000),
-      }
+  async authenticate(): Promise<void> { 
+    const path: string = this.tokenPath;
+    this.debug(`Checking for existing token at: ${path}`);
 
-      this.httpClient.defaults.headers.common.Authorization = `Bearer ${this.credentials.access_token}`
+    if (!fs.existsSync(path)) {
+      try {
+          await this.getAuthToken();
+
+      } catch (error) {
+        const err = new Error(`Authentication error caught in authenticate(): ${error}`)
+        this.emit('error', err)
+        throw err
+      }
+    } else {
       this.emit('authenticated')
-      this.log('Authenticated successfully')
-    } catch (error) {
-      const err = new Error(`Authentication failed: ${error}`)
-      this.emit('error', err)
-      throw err
     }
+  } 
+
+   /**
+   * Refresh the access token using refresh_token
+   */
+  async refreshAccessToken() {
+    this.debug('Refreshing access token using staticrefresh_token')
+    return await this.getAccessToken({
+      grant_type:     'refresh_token',
+      client_id:      this.config.clientId,
+      client_secret:  this.config.clientSecret,
+      refresh_token:  SmartHQClient.refresh_token
+    });
   }
 
   /**
-   * Refresh the access token using refresh_token
+   * Perform OAuth2 authentication flow
    */
-  async refreshToken(): Promise<void> {
-    if (!this.credentials?.refresh_token) {
-      throw new Error('No refresh token available')
-    }
+  private async getAuthToken(): Promise<any> {
 
+    // Step 1: Redirect user to SmartHQ authorization endpoint to obtain authorization code
+
+    const app = express();
+    const url = new URL(`${this.config.redirectUri}`);
+    const pathname: string = url.pathname;      // e.g. '/callback'
+    const port: number = parseInt(url.port, 10);
+
+    const tstamp = new Date().toLocaleString('en-US')
+    console.log(chalk.blue(`[${tstamp}] [SmarthqClient] =======================================================================`));
+    console.log(chalk.blue(`[${tstamp}] [SmarthqClient] Click to login for SmartHQ Auth setup ===>:` + chalk.red("http://localhost:" + port + "/login")));
+    console.log(chalk.blue(`[${tstamp}] [SmarthqClient] =======================================================================`));
+    
+ 
+    app.get('/login', async (_req, res) => {
     try {
-      const response = await axios.post(`${LOGIN_URL}/oauth2/token`, {
-        refresh_token: this.credentials.refresh_token,
-        client_id: OAUTH2_CLIENT_ID,
-        client_secret: OAUTH2_CLIENT_SECRET,
-        grant_type: 'refresh_token',
-      }, {
-        auth: {
-          username: OAUTH2_CLIENT_ID,
-          password: OAUTH2_CLIENT_SECRET,
-        },
-      })
+      const url = `${LOGIN_URL}/oauth2/auth?` + stringify({
+        response_type:  'code',
+        client_id:      this.config.clientId || 'not_set',
+        redirect_uri:   `${this.config.redirectUri}`,
+      });
 
-      this.credentials = {
-        access_token: response.data.access_token,
-        token_type: response.data.token_type || 'Bearer',
-        expires_in: response.data.expires_in,
-        refresh_token: response.data.refresh_token || this.credentials.refresh_token,
-        expires: Date.now() + ((response.data.expires_in || 3600) * 1000),
+      res.redirect(url);     ///====> Redirect to SmartHQ authorization endpoint
+ 
+    } catch (error) {
+      console.error(chalk.blue(`[${tstamp}] [SmarthqClient] /login error: caught in getAuthToken`, error));
+      res.status(500).send('Authentication /login failed: ' + error);};
+    });
+
+  app.get(pathname, async (req, res) => {   // /callback route handler for SmartHQ OAuth redirect with authorization code
+    try {
+      // Parse the request URL
+      const query = parse(req.url!.split('?')[1]);
+
+      const code = query.code?.toString() || '';
+      if (!code) {
+        console.error(chalk.blue(`[${tstamp}] [SmarthqClient] No code found in callback URL for SmartHQ OAuth`));
       }
 
-      this.httpClient.defaults.headers.common.Authorization = `Bearer ${this.credentials.access_token}`
-      this.emit('token_refreshed')
-      this.log('Token refreshed successfully')
+    // Step 2: Exchange authorization code for access token
+
+      await this.exchangeCodeForToken(code);
+
+      res.send(`
+        <h2>SmartHQ Connected</h2>
+        <p>Authorization token saved to file.</p>
+        <p>You may close this window.</p>
+      `);
+
+      setTimeout(() => this.oauthServer?.close(), 1000);
+      return(code);
+
     } catch (error) {
-      const err = new Error(`Token refresh failed: ${error}`)
-      this.emit('error', err)
-      throw err
+      console.error(chalk.blue(`[${tstamp}] [SmarthqClient] /callback error: caught in getAuthToken`, error));
+      res.status(500).send('Authentication failed: ' + error);
     }
+  });
+  this.oauthServer = app.listen(port, () => {
+    this.debug(`SmartHQ OAuth listening on ${port}`);
+  });
+      
+}
+
+  async exchangeCodeForToken(code: string) {
+    return this.getAccessToken({
+      grant_type:     'authorization_code',
+      client_id:      this.config.clientId,
+      client_secret:  this.config.clientSecret,
+      redirect_uri:   this.config.redirectUri,
+      code:           code
+    });
+  }
+//*======================================================================================
+   async getAccessToken(requestBody: Record<string, string>) {
+    try {
+      const response = await this.httpClient.post(
+        `${LOGIN_URL}/oauth2/token`,
+        stringify(requestBody),
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+      );
+      
+      this.saveToken(response.data);
+    } catch (error) {
+      console.error(chalk.blue(`[${new Date().toLocaleString('en-US')}] [SmarthqClient] Error caught in getAccessToken:`, error));
+      throw await this.handleApiError('Failed to get access token', error)
+    }
+  }
+
+  saveToken(data: AxiosResponse['data']) {
+    SmartHQClient.refresh_token = data.refresh_token;
+    SmartHQClient.access_token = data.access_token;
+    SmartHQClient.expires = Date.now() + data.expires_in * 1000;
+   // Object.assign(this, data);
+    try {
+      writeFileSync(this.tokenPath, JSON.stringify(data, null, 2));
+    } catch (error) {
+      const tstamp = new Date().toLocaleString('en-US')
+      console.error(chalk.blue(`[${tstamp}] [SmarthqClient] Error saving token: `, error));
+    }
+  }
+
+  loadAccessToken() {
+    if (!existsSync(this.tokenPath)) return;
+    const data: string = readFileSync(this.tokenPath).toString('utf8');
+    const tokenData = JSON.parse(data);
+    // Object.assign(this, tokenData);
+    SmartHQClient.refresh_token = tokenData.refresh_token;
+    SmartHQClient.access_token = tokenData.access_token;
+    SmartHQClient.expires = Date.now() + tokenData.expires_in * 1000;
+  }
+
+  getWebSocket() {
+    return this.websocket;
   }
 
   /**
    * Connect to the WebSocket for real-time updates
    */
   async connect(): Promise<void> {
-    if (!this.credentials) {
+    if (!SmartHQClient.access_token) {
       throw new Error('Not authenticated. Call authenticate() first.')
     }
 
     try {
       const wsEndpoint = await this.getWebSocketEndpoint()
-      this.log(`Connecting to WebSocket: ${wsEndpoint.endpoint}`)
 
       this.websocket = new WebSocket(wsEndpoint.endpoint)
 
       this.websocket.on('open', () => {
-        this.log('WebSocket connected')
         this.reconnectAttempts = 0
         this.emit('connected')
+        this.debug('WebSocket connection established')
         this.setupPingPong()
         this.configureWebSocket()
       })
@@ -193,7 +296,7 @@ export class SmartHQClient extends EventEmitter {
       })
 
       this.websocket.on('close', () => {
-        this.log('WebSocket disconnected, attempting to reconnect...')
+        this.debug('WebSocket connection closed')
         this.emit('disconnected')
         this.clearPingPong()
         this.attemptReconnect()
@@ -201,11 +304,12 @@ export class SmartHQClient extends EventEmitter {
 
       this.websocket.on('error', (error: Error) => {
         this.emit('error', error)
+        this.debug('WebSocket connection error: ' + error.message)
       })
     } catch (error) {
       const err = new Error(`WebSocket connection failed: ${error}`)
       this.emit('error', err)
-      throw err
+      console.error(chalk.blue(`[${new Date().toLocaleString('en-US')}] [SmarthqClient] WebSocket connection error:`, error));
     }
   }
 
@@ -213,7 +317,7 @@ export class SmartHQClient extends EventEmitter {
    * Disconnect from the WebSocket
    */
   async disconnect(): Promise<void> {
-    this.log('Disconnecting WebSocket')
+    this.debug('Disconnecting WebSocket')
     this.clearPingPong()
     if (this.websocket) {
       this.websocket.close()
@@ -235,19 +339,24 @@ export class SmartHQClient extends EventEmitter {
   /**
    * Get list of devices with optional filtering and pagination
    */
-  async getDevices(params?: Record<string, any>): Promise<DeviceListResponse> {
+  async getDevices(): Promise<DeviceListResponse> {
     try {
-      const response = await this.httpClient.get<DeviceListResponse>('/v2/device', { params })
-
+      const response = await this.httpClient.get<DeviceListResponse>('/v2/device',
+        { headers: await this.httpHeaders() }
+      );
       // Cache devices
-      for (const device of response.data.items) {
+      for (const device of response.data.devices) {
         this.devices.set(device.deviceId, device)
       }
-
-      this.log(`Retrieved ${response.data.items.length} devices`)
       return response.data
-    } catch (error) {
-      throw this.handleApiError('Failed to get devices', error)
+    } catch (error: AxiosError | any) {
+        if (error.response?.status === 401) {
+          await this.refreshAccessToken();
+          return await this.getDevices();
+        } else {
+          throw this.handleApiError('Failed to get devices', error)
+        }
+        
     }
   }
 
@@ -256,12 +365,17 @@ export class SmartHQClient extends EventEmitter {
    */
   async getDevice(deviceId: string): Promise<Device> {
     try {
-      const response = await this.httpClient.get<Device>(`/v2/device/${deviceId}`)
-      this.devices.set(deviceId, response.data)
-      this.log(`Retrieved device: ${deviceId}`)
+      const response = await this.httpClient.get<Device>(`/v2/device/${deviceId}`,
+        { headers: await this.httpHeaders() });
+      this.devices.set(deviceId, response.data);
       return response.data
-    } catch (error) {
-      throw this.handleApiError(`Failed to get device ${deviceId}`, error)
+    } catch (error: AxiosError | any) {
+        if (error.response?.status === 401) {
+          await this.refreshAccessToken();
+          return await this.getDevice(deviceId);
+        } else {
+          throw this.handleApiError(`Failed to get device ${deviceId}`, error)
+        }
     }
   }
 
@@ -270,7 +384,7 @@ export class SmartHQClient extends EventEmitter {
    */
   async getDeviceCount(params?: Record<string, any>): Promise<DeviceCountResponse> {
     try {
-      const response = await this.httpClient.get<DeviceCountResponse>('/v2/device/count', { params })
+      const response = await this.httpClient.get<DeviceCountResponse>('/v2/device/count', { params, headers: await this.httpHeaders() })
       return response.data
     } catch (error) {
       throw this.handleApiError('Failed to get device count', error)
@@ -284,13 +398,17 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<ServiceDetailsResponse>(
         `/v2/device/${deviceId}/service/${serviceId}`,
-      )
+        { headers: await this.httpHeaders() }); 
       return response.data
-    } catch (error) {
-      throw this.handleApiError(
-        `Failed to get service details for ${deviceId}/${serviceId}`,
-        error,
-      )
+    } catch (error: AxiosError | any) {
+        if (error.response?.status === 401) {
+          await this.refreshAccessToken();
+          return await this.getServiceDetails(deviceId, serviceId);
+        } else {
+          throw this.handleApiError(
+            `Failed to get service details for ${deviceId}/${serviceId}`
+            , error)
+        }
     }
   }
 
@@ -305,7 +423,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<ServiceHistoryResponse>(
         `/v2/device/${deviceId}/service/${serviceId}/history`,
-        { params },
+        { params, headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -325,13 +443,29 @@ export class SmartHQClient extends EventEmitter {
     command: Record<string, any>,
   ): Promise<void> {
     try {
-      await this.httpClient.post(`/v2/device/${deviceId}/service/${serviceId}`, command)
-      this.log(`Updated service ${serviceId} on device ${deviceId}`)
+      await this.httpClient.post(`/v2/device/${deviceId}/service/${serviceId}`, 
+        command, 
+        { headers: await this.httpHeaders() });
     } catch (error) {
       throw this.handleApiError(
         `Failed to update service ${serviceId} on device ${deviceId}`,
         error,
       )
+    }
+  }
+  /**
+   * Send command to device.
+   */
+  async sendCommand(request: SendCommandRequest): Promise<SendCommandSuccessResponse> {
+    try {
+      const response = await this.httpClient.post<SendCommandSuccessResponse>(
+        '/v2/command',
+        request,
+        { headers: await this.httpHeaders() }
+      )
+      return response.data
+    } catch (error) {
+      throw this.handleApiError('Failed to send command', error)
     }
   }
 
@@ -341,10 +475,10 @@ export class SmartHQClient extends EventEmitter {
   async sendCommands(request: SendCommandsRequest): Promise<SendCommandsSuccessResponse> {
     try {
       const response = await this.httpClient.post<SendCommandsSuccessResponse>(
-        '/v2/command',
+        '/v2/commands',
         request,
+        { headers: await this.httpHeaders() }
       )
-      this.log(`Sent ${request.commands.length} command(s)`)
       return response.data
     } catch (error) {
       throw this.handleApiError('Failed to send commands', error)
@@ -358,7 +492,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<DeviceAlertsResponse>(
         `/v2/device/${deviceId}/alert`,
-        { params },
+        { params, headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -376,7 +510,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<DevicePresenceResponse>(
         `/v2/device/${deviceId}/presence`,
-        { params },
+        { params, headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -395,6 +529,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.post(
         `/v2/device/${deviceId}/history`,
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -413,6 +548,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.post(
         `/v2/device/${deviceId}/history/calculated`,
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -420,6 +556,8 @@ export class SmartHQClient extends EventEmitter {
     }
   }
 
+
+  
   /**
    * Get recent alerts across all devices
    */
@@ -427,7 +565,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<RecentAlertResponse>(
         '/v2/alert/recent',
-        { params },
+        { params, headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -445,7 +583,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<AlertReport>(
         `/v2/alert/${alertType}/report`,
-        { params },
+        { params, headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -460,7 +598,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<AlertCountResponse>(
         '/v2/alert/count',
-        { params },
+        { params, headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -478,8 +616,8 @@ export class SmartHQClient extends EventEmitter {
     try {
       await this.httpClient.delete(
         `/v2/device/${deviceId}/alert/${alertType}`,
+        { headers: await this.httpHeaders() },
       )
-      this.log(`Deleted alert ${alertType} for device ${deviceId}`)
     } catch (error) {
       throw this.handleApiError(`Failed to delete alert for device ${deviceId}`, error)
     }
@@ -496,7 +634,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<FavoritesResponse>(
         '/v2/favorite',
-        { params },
+        { params , headers: await this.httpHeaders()},
       )
       return response.data
     } catch (error) {
@@ -512,6 +650,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.post<SaveFavoriteResponse>(
         '/v2/favorite',
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -530,6 +669,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.put<UpdateFavoriteResponse>(
         `/v2/favorite/${favoriteId}`,
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -547,6 +687,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.put<UpdateFavoriteOrderResponse>(
         '/v2/favorite/order',
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -559,8 +700,9 @@ export class SmartHQClient extends EventEmitter {
    */
   async deleteFavorite(favoriteId: string): Promise<void> {
     try {
-      await this.httpClient.delete(`/v2/favorite/${favoriteId}`)
-      this.log(`Deleted favorite ${favoriteId}`)
+      await this.httpClient.delete(`/v2/favorite/${favoriteId}`,
+        { headers: await this.httpHeaders() },
+      )
     } catch (error) {
       throw this.handleApiError(`Failed to delete favorite ${favoriteId}`, error)
     }
@@ -577,7 +719,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<GatewayListResponse>(
         '/v2/gateway',
-        { params },
+        { params, headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -593,6 +735,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.post<GatewayResponse>(
         '/v2/gateway',
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -606,8 +749,8 @@ export class SmartHQClient extends EventEmitter {
   async removeGateway(gatewayId: string, force: boolean = false): Promise<void> {
     try {
       const params = force ? { force: 'true' } : {}
-      await this.httpClient.delete(`/v2/gateway/${gatewayId}`, { params })
-      this.log(`Removed gateway ${gatewayId}`)
+      await this.httpClient.delete(`/v2/gateway/${gatewayId}`, 
+        { params, headers: await this.httpHeaders() })
     } catch (error) {
       throw this.handleApiError(`Failed to remove gateway ${gatewayId}`, error)
     }
@@ -620,6 +763,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<GatewayTagsResponse>(
         `/v2/gateway/${gatewayId}/tag`,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -638,6 +782,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.post<GatewayTagsManageResponse>(
         `/v2/gateway/${gatewayId}/tag`,
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -652,8 +797,8 @@ export class SmartHQClient extends EventEmitter {
     try {
       await this.httpClient.delete(`/v2/gateway/${gatewayId}/tag`, {
         data: { tagNames },
+        headers: await this.httpHeaders(),
       })
-      this.log(`Deleted tags for gateway ${gatewayId}`)
     } catch (error) {
       throw this.handleApiError(`Failed to delete tags for gateway ${gatewayId}`, error)
     }
@@ -670,6 +815,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<DeviceSetting[]>(
         `/v2/device/${deviceId}/setting`,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -684,6 +830,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<DeviceSettingResponse>(
         `/v2/device/${deviceId}/setting/${ruleId}`,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -710,6 +857,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.post<DeviceSetTagResponse>(
         `/v2/device/${deviceId}/tag/${tagName}`,
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -728,6 +876,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.post<GetTagValuesResponse>(
         `/v2/tag/${tagName}/value`,
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -746,6 +895,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<FileDownloadResponse>(
         `/v2/file/${fileId}`,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -764,6 +914,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<SchemaListResponse>(
         '/v2/schema',
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -778,6 +929,7 @@ export class SmartHQClient extends EventEmitter {
     try {
       const response = await this.httpClient.get<SchemaResponse>(
         `/v2/schema/${schemaName}`,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -796,6 +948,7 @@ export class SmartHQClient extends EventEmitter {
       const response = await this.httpClient.post<SchemaPolicyValidationResponse>(
         `/v2/schema/${schemaName}`,
         request,
+        { headers: await this.httpHeaders() },
       )
       return response.data
     } catch (error) {
@@ -832,18 +985,19 @@ export class SmartHQClient extends EventEmitter {
     const config: PubsubConfig = {
       kind: 'websocket#pubsub',
       action: 'pubsub',
+      pubsub: true,
       services: true,
       alerts: true,
       presence: true,
       commands: true,
     }
+   
 
-    this.websocket.send(JSON.stringify(config))
-    this.log('Configured WebSocket subscriptions')
+    const response = this.websocket.send(JSON.stringify(config))
   }
 
   /**
-   * Set up ping/pong keep-alive (30 seconds)
+   * Set up ping/pong keep-alive (60 seconds)
    */
   private setupPingPong(): void {
     if (!this.websocket) {
@@ -861,13 +1015,11 @@ export class SmartHQClient extends EventEmitter {
 
         // Set timeout waiting for pong
         this.pongTimeout = setTimeout(() => {
-          this.log('Pong timeout - reconnecting')
+          this.debug('Pong timeout - reconnecting')
           this.websocket?.close()
         }, 10000)
       }
-    }, 30000)
-
-    this.log('Ping/pong keep-alive initialized')
+    }, PING_INTERVAL)
   }
 
   /**
@@ -943,11 +1095,11 @@ export class SmartHQClient extends EventEmitter {
       delay,
     })
 
-    this.log(`Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`)
+    this.debug(`Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`)
 
     setTimeout(async () => {
       try {
-        await this.refreshToken()
+        await this.refreshAccessToken();
         await this.connect()
       } catch (error) {
         this.emit('error', new Error(`Reconnection failed: ${error}`))
@@ -964,129 +1116,77 @@ export class SmartHQClient extends EventEmitter {
    */
   private async getWebSocketEndpoint(): Promise<WebsocketEndpoint> {
     try {
-      const response = await this.httpClient.get<WebsocketEndpoint>('/v2/websocket')
+      const response = await this.httpClient.get<WebsocketEndpoint>('/v2/websocket',
+        { headers: await this.httpHeaders() }
+      );
       return response.data
     } catch (error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) {
+        await this.refreshAccessToken();
+        return await this.getWebSocketEndpoint();
+        }
+      }
       throw this.handleApiError('Failed to get WebSocket endpoint', error)
     }
   }
 
-  /**
-   * Perform OAuth2 authentication flow
-   */
-  private async getOAuth2Token(): Promise<any> {
-    try {
-      const region = LOGIN_REGIONS[this.config.region || 'US'] || LOGIN_REGIONS.US
-      const cookieHeader = `abgea_region=${region}; Domain=accounts.brillion.geappliances.com; Path=/`
-
-      // Step 1: Get authorization page
-      const authParams = {
-        client_id: OAUTH2_CLIENT_ID,
-        response_type: 'code',
-        access_type: 'offline',
-        redirect_uri: OAUTH2_REDIRECT_URI,
-      }
-
-      const authResponse = await axios.get(`${LOGIN_URL}/oauth2/auth`, {
-        params: authParams,
-        headers: { Cookie: cookieHeader },
-        validateStatus: () => true,
-      })
-
-      // Step 2: Extract form data from HTML response
-      const formDataMatch = authResponse.data.match(/<form[^>]*id="frmsignin"[^>]*>([\s\S]*?)<\/form>/)
-      if (!formDataMatch) {
-        throw new Error('Could not find login form in authentication response')
-      }
-
-      const inputMatches = formDataMatch[1].match(/<input[^>]*name="([^"]+)"[^>]*value="([^"]*)"[^>]*>/g) || []
-      const formData: Record<string, string> = {}
-
-      for (const inputMatch of inputMatches) {
-        const nameMatch = inputMatch.match(/name="([^"]+)"/)
-        const valueMatch = inputMatch.match(/value="([^"]*)"/)
-        if (nameMatch && valueMatch) {
-          formData[nameMatch[1]] = valueMatch[1]
-        }
-      }
-
-      // Step 3: Add credentials
-      formData.username = this.config.username
-      formData.password = this.config.password
-
-      // Step 4: Submit login form
-      const loginResponse = await axios.post(`${LOGIN_URL}/oauth2/g_authenticate`, formData, {
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Cookie': cookieHeader,
-        },
-        maxRedirects: 0,
-        validateStatus: () => true,
-      })
-
-      // Step 5: Extract authorization code from redirect
-      let authCode: string
-      const redirectUrl = loginResponse.headers.location || loginResponse.headers.Location
-      if (loginResponse.status === 302 && redirectUrl) {
-        const urlParams = new URLSearchParams(redirectUrl.split('?')[1])
-        authCode = urlParams.get('code')!
-      } else {
-        throw new Error('Failed to get authorization code from login response')
-      }
-
-      // Step 6: Exchange code for token
-      const tokenResponse = await axios.post(`${LOGIN_URL}/oauth2/token`, {
-        code: authCode,
-        client_id: OAUTH2_CLIENT_ID,
-        client_secret: OAUTH2_CLIENT_SECRET,
-        redirect_uri: OAUTH2_REDIRECT_URI,
-        grant_type: 'authorization_code',
-      }, {
-        auth: {
-          username: OAUTH2_CLIENT_ID,
-          password: OAUTH2_CLIENT_SECRET,
-        },
-        validateStatus: () => true,
-      })
-
-      if (tokenResponse.status !== 200) {
-        throw new Error(`Token exchange failed with status ${tokenResponse.status}`)
-      }
-
-      return tokenResponse.data
-    } catch (error) {
-      throw new Error(`OAuth2 token retrieval failed: ${error}`)
-    }
-  }
-
+  
   /**
    * Handle API errors with consistent formatting
    */
-  private handleApiError(message: string, error: any): Error {
+ public async handleApiError(message: string, error: any): Promise<Error> {
     let errorMsg = message
 
     if (error.response?.status === 401) {
-      errorMsg += ' - Unauthorized (invalid credentials)'
+      errorMsg += ' - Unauthorized (invalid access token)'
+      await this.refreshAccessToken().catch((refreshError) => {
+        this.debug(`Token refresh failed: ${refreshError}`)
+        this.emit('error', new Error(`Token refresh failed: ${refreshError}`))
+      })
+    } else if (error.response?.status === 400) {
+      errorMsg += ' - Bad Request (missing or invalid parameters)'
     } else if (error.response?.status === 403) {
       errorMsg += ' - Forbidden (insufficient permissions)'
     } else if (error.response?.status === 404) {
       errorMsg += ' - Not found'
+    } else if (error.response?.status === 408) {
+      errorMsg += ' - Request Timeout'
+    } else if (error.response?.status === 409) {
+      errorMsg += ' - Device not removable)'
+    } else if (error.response?.status === 412) {
+      errorMsg += ' - Gateway offline or tag managed at gateway level'
     } else if (error.response?.status === 429) {
       errorMsg += ' - Rate limited'
     } else if (error.message) {
       errorMsg += ` - ${error.message}`
     }
-
     return new Error(errorMsg)
+  }
+
+  /**
+   * Intercept expired access token errors and attempt to refresh token before retrying request
+   */
+
+   async httpHeaders() {
+    if (!SmartHQClient.access_token || Date.now() > SmartHQClient.expires - 60000) { // Refresh token if it's expired or will expire in the next 1 minute (tokens are valid for 60 minutes)
+      try {
+        await this.refreshAccessToken();
+      } catch (error: any) {
+        this.debug( 'Failed to refresh access token in httpHeaders: ' + error.response?.status);
+      }
+    }
+    return { Authorization: `Bearer ${SmartHQClient.access_token}` };
   }
 
   /**
    * Internal logging utility (respects debug config)
    */
-  private log(message: string): void {
+  public debug(message: string): void {
+
     if (this.config.debug) {
-      // eslint-disable-next-line no-console
-      console.log(`[SmartHQClient] ${message}`)
+      const tstamp = new Date().toLocaleString('en-US')
+      console.log(chalk.white(`[${tstamp}]` + chalk.yellow(` [SmartHQClient] ${message}`)));
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,5 +46,5 @@
  * ```
  */
 
-export * from './types/index';
-export { SmartHQClient } from './api/ge-client';
+export * from './types/index.js';
+export { SmartHQClient } from './api/ge-client.js';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,9 +2,7 @@
  * Configuration for SmartHQ API client
  */
 export interface SmartHQConfig {
-  username: string
-  password: string
-  region?: 'US' | 'EU'
+  redirectUri: string
   debug?: boolean
 }
 
@@ -12,7 +10,7 @@ export interface SmartHQConfig {
  * OAuth2 credentials
  */
 export interface SmartHQCredentials {
-  access_token: string
+  access_token?: string
   token_type: string
   expires_in: number
   refresh_token?: string
@@ -24,32 +22,35 @@ export interface SmartHQCredentials {
 // ============================================================================
 
 export interface Device {
-  deviceId: string
-  deviceType: string
-  userId: string
-  applianceId?: string
-  adapterId?: string
-  nickname?: string
-  online?: string
-  jid?: string
-  macAddress?: string
-  serialNumber?: string
-  modelNumber?: string
-  services?: DeviceService[]
-  lastSyncTime?: string
-  gatewayId?: string
-  metadata?: Record<string, any>
+  deviceId: string;
+  deviceType: string;
+  services?: DeviceService[];
+  lastSyncTime: string;
+  roomNumber: string;
+  serial: string;
+  lastPresenceTime: string;
+  createdDateTime: string;
+  presence: string;
+  gatewayId: string;
+  room: string;
+  icon: string;
+  manufacturer: string;
+  nickname: string;
+  model: string;
+  floor: string;
+  macAddress: string;
 }
 
 export interface DeviceService {
-  serviceId: string
-  serviceType: string
-  domainType: string
-  serviceDeviceType: string
-  lastStateTime?: string
-  lastSyncTime?: string
-  state?: Record<string, any>
-  config?: Record<string, any>
+  serviceId: string;
+  serviceType: string;
+  domainType: string;
+  serviceDeviceType: string;
+  supportedCommands: string[];
+  state?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+  lastStateTime?: string;
+  lastSyncTime?: string;
 }
 
 // ============================================================================
@@ -58,7 +59,7 @@ export interface DeviceService {
 
 export interface DeviceListResponse {
   total: number
-  items: Device[]
+  devices: Device[]
   page?: number
   perPage?: number
 }
@@ -209,14 +210,30 @@ export interface CommandRequest {
   [key: string]: any
 }
 
+export interface SendCommandRequest {
+  kind: string
+  deviceId: string
+  serviceType: string
+  domainType: string
+  serviceDeviceType: string
+  command: Record<string, any>
+  successOnNoDeviceMatches?: boolean
+}
+
+export interface SendCommandSuccessResponse {
+  correlationId: string
+  timestamp: string
+}
+
 export interface SendCommandsRequest {
-  kind: 'appliance#command-request'
+  kind: string
   commands: CommandRequest[]
 }
 
 export interface SendCommandsSuccessResponse {
+  success: boolean
+  outcome: string
   correlationId: string
-  timestamp: string
 }
 
 export interface CommandResponse {
@@ -415,10 +432,12 @@ export interface AlertReport {
 }
 
 export interface AlertHistoryEntry {
-  alertId: string
+  deviceType: string
+  lastAlertTime: string
   alertType: string
+  model: string
+  lastAlertId: string
   deviceId: string
-  timestamp: string
   severity?: string
   message?: string
   resolved?: boolean
@@ -430,7 +449,8 @@ export interface AlertCountResponse {
 }
 
 export interface RecentAlertResponse {
-  items: AlertHistoryEntry[]
+  alerts: AlertHistoryEntry[]
+  //items: AlertHistoryEntry[]
   total?: number
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@
  * Configuration for SmartHQ API client
  */
 export interface SmartHQConfig {
+  clientId: string
+  clientSecret: string
   redirectUri: string
   debug?: boolean
 }
@@ -450,7 +452,6 @@ export interface AlertCountResponse {
 
 export interface RecentAlertResponse {
   alerts: AlertHistoryEntry[]
-  //items: AlertHistoryEntry[]
   total?: number
 }
 


### PR DESCRIPTION
## :recycle: Current situation

_Current OAuth2 authentication uses a 'headless' operation to obtain auth code needed to acquire an access token. That doesn't work with the Digital Twin API which requires a http or https redirectUri.

User name and password are used as part of a 'headless' OAuth2 authentication flow.

Global headers (for authentication) cause issue when using refresh token to acquire a new access token. (The auth header should not be used for that request)

Vars for access_token, refresh_token and expire are not declared as static so each instantiation obtains/uses different tokens.

No function for sending command to single device_

## :bulb: Proposed solution

_Change OAuth2 flow to start it's own localhost server to be used as the redirect uri endpoint. The auth code is obtained from there and then exchanged for an access token and refresh token.  The tokens are saved to a file on local system. This will require (only for initial time or when no access token exists) user intervention to click on highlighted link in Homebridge log to redirect to SmartHQ auth endpoint and login with their username/password. If they agree to conditions the submit will include the auth code as part of the url to redirect uri.

Remove username and password since they become part of the user login in new flow.
Require file 'config.schema.json' to include entries for clientId, clientSecret, redirectUri  (example code in README.md in Homebridge Integration)

Change use of global headers to a httpHeaders() function called by each command which tests if token doesn't exist or has expired. If true then refreshAccessToken() is called.  This will help prevent unnecessary  (401) invalid credential errors. 

Change access_token, refresh_token and expire to static variables so all instantiations use same set of tokens. (I currently have a separate class for every refrigerator service in my plugin so was observing lots of refreshes prior to change to static)

Add new function sendCommand()  to send commands to a single device. (function sendCommands() sends to multiple devices)_

## :gear: Release Notes

_
- OAuth2 initial authentication process for Digital Twin API
- Client Id and Client secret passed via config.schema.json
- Access, refresh tokens and expire changed to static vars
- Additional error handling for 401 (invalid credentials) errors
- Add new function 'sendCommand' for command to single device
- Handling of the http headers (authorization)
- Add requirement for initial setup of SmartHQ account in order to use Digital Twin API (see README.md) [Get Started - SmartHQ Docs](https://docs.smarthq.com/get-started/)
_

## :heavy_plus_sign: Additional Information

_sample config.schema.json_

```typescript
{
  "pluginAlias": "SmartHqPlatform",
  "pluginType": "platform",
  "singular": true,
  "schema": {
    "type": "object",
    "required": ["clientId", "clientSecret", "redirectUri"],
    "properties": {
      "clientId": {
        "type": "string",
        "title": "SmartHQ Client ID",
        "x-schema-form": {
          "type": "password"
        }
      },
      "clientSecret": {
        "type": "string",
        "title": "SmartHQ Client Secret",
        "x-schema-form": {
          "type": "password"
        }
      },
      "redirectUri": {
        "type": "string",
        "format": "uri",
        "title": "OAuth Redirect URI (must match the one defined  for SmartHQ app @ https://developer.smarthq.com/user/???/apps",
        "default": "http://localhost:8888/callback"
      },
      "debugLogging": {
        "type": "boolean",
        "title": "Plugin Debug Logging",
        "default": false
      },
    }
```

### Testing

_Tests only modified to correct var names._

### Reviewer Nudging

_In CHANGELOG.md I entered version as ?.?.?.  Change as needed. 
My first Pull request so let me know if I need more info or left something out._
