### PR TITLE
add new fields to type SendCommandSuccessResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.2](https://github.com/homebridge-plugins/ge-smarthq/releases/tag/v1.0.2) (2026-04-08)
+
+## What's Changed
+- Added two additional fields (outcome, success) to type SendCommandSuccesResponse 
+
 ## [1.0.1](https://github.com/homebridge-plugins/ge-smarthq/releases/tag/v1.0.1) (2026-03-17)
 
 ## What's Changed

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -225,6 +225,8 @@ export interface SendCommandRequest {
 export interface SendCommandSuccessResponse {
   correlationId: string
   timestamp: string
+  outcome: string
+  success: boolean
 }
 
 export interface SendCommandsRequest {


### PR DESCRIPTION
## :recycle: Current situation

_Unable to determine 'success' (true/false) or 'outcome' (string) from response.data returned by 'sendCommand'. Previously you had to test for a http response of 200 which might still have different outcomes._

## :bulb: Proposed solution

_Update type SendCommandSuccessResponse with additional fields. This allows for more detailed information to be tested for when calling the api sendCommand function._

## :gear: Release Notes

_No change._

## :heavy_plus_sign: Additional Information

_CHANGELOG.md updated._

### Testing

_No new tests._


